### PR TITLE
GAL dump full contact data

### DIFF
--- a/thumbscrews/cli.py
+++ b/thumbscrews/cli.py
@@ -495,7 +495,7 @@ def gal(dump, search, verbose, full, output):
     elif full:
         atoz = [''.join(x) for x in itertools.product(string.ascii_lowercase, repeat=2)]
         for entry in atoz:
-            for names in ResolveNames(account.protocol).call(unresolved_entries=(entry,)):
+            for names in ResolveNames(account.protocol).call(unresolved_entries=(entry,), return_full_contact_data=True,):
                 stringed = str(names)
                 found = re.findall(r'[\w.+-]+@[\w-]+\.[\w.-]+', stringed)
                 for i in found:


### PR DESCRIPTION
Hello

Added `return_full_contact_data=True` to `ResolveNames.call()` when dumping GAL with full (`-f`) option enabled.
This returns more interesting directory and users info. 

Ref: https://ecederstrand.github.io/exchangelib/exchangelib/services/resolve_names.html

